### PR TITLE
Add `regExp` property to options in order to allow n-th matched placeholders to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ And run `webpack` via your preferred method.
 
 ## Options
 
+### `regExp`
+
+Type: `RegExp`
+Default: `undefined`
+
+The regular expression to match if, for instance, you want to use the n-th matched placeholder.
+
+```js
+// webpack.config.js
+{
+  loader: 'awesome-worker-loader',
+  options: {
+      name: '[1].js',
+      regExp: /(worker1|worker2)\.worker\.js$/
+  },
+}
+```
+
+This will result in the name of the output script being "worker1.js" or "worker2.js" (whichever is matched);
+
 ### `type`
 
 Type: `string`

--- a/src/options.json
+++ b/src/options.json
@@ -4,6 +4,9 @@
     "name": {
       "type": "string"
     },
+    "regExp": {
+      "instanceof": "RegExp"
+    },
     "inline": {
       "type": "boolean"
     },
@@ -13,7 +16,7 @@
     "publicPath": {
       "type": "string"
     },
-    "type":{
+    "type": {
       "type": "string"
     }
   },

--- a/test/fixtures/regexp-options/entry.js
+++ b/test/fixtures/regexp-options/entry.js
@@ -1,0 +1,2 @@
+const test1 = require('./test1.worker.js');
+const test2 = require('./test2.worker.js');

--- a/test/fixtures/regexp-options/test1.worker.js
+++ b/test/fixtures/regexp-options/test1.worker.js
@@ -1,0 +1,1 @@
+// w1 via worker options

--- a/test/fixtures/regexp-options/test2.worker.js
+++ b/test/fixtures/regexp-options/test2.worker.js
@@ -1,0 +1,1 @@
+// w2 via worker options

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -50,6 +50,29 @@ test('should create chunk with specified name in query', () =>
     );
   }));
 
+test('should use regexp from options', () =>
+  webpack('regexp-options', {
+    loader: {
+      test: /(test1|test2)\.worker\.js$/,
+      options: {
+        name: '[1].js',
+        regExp: /(test1|test2)\.worker\.js$/
+      },
+    },
+  }).then((stats) => {
+    const files = stats
+      .toJson()
+      .children.map((item) => item.chunks)
+      .reduce((acc, item) => acc.concat(item), [])
+      .map((item) => item.files)
+      .map((item) => `__expected__/regexp-options/${item}`)
+      .sort();
+
+    assert.equal(files.length, 2);
+    assert.equal(files[0], '__expected__/regexp-options/test1.js');
+    assert.equal(files[1], '__expected__/regexp-options/test2.js');
+  }));
+
 test('should create named chunks with workers via options', () =>
   webpack('name-options', {
     loader: {


### PR DESCRIPTION
- Add `regExp` property to options schema.
- Add a test checking if the `regExp` options property is used correctly.